### PR TITLE
HTTPS fixes

### DIFF
--- a/lib/geomap.js
+++ b/lib/geomap.js
@@ -10,10 +10,10 @@ function init() {
 
   L.control.scale().addTo(map);
 
-  map.addLayer(new L.TileLayer("http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg", {
+  map.addLayer(new L.TileLayer("//otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg", {
     subdomains: '1234',
     type: 'osm',
-    attribution: 'Map data Tiles &copy; <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png" />, Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, CC-BY-SA',
+    attribution: 'Map data Tiles &copy; <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="//developer.mapquest.com/content/osm/mq_logo.png" />, Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, CC-BY-SA',
     opacity: 0.7,
   }))
 

--- a/meshviewer.html
+++ b/meshviewer.html
@@ -21,7 +21,7 @@
       </ul>
     </header>
 	
-	<iframe src="http://bremen.freifunk.net/meshviewer/" style="position:fixed; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;"></iframe>
+	<iframe src="//bremen.freifunk.net/meshviewer/" style="position:fixed; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;"></iframe>
 	
   </body>
 </html>


### PR DESCRIPTION
Hiermit werden die letzten Mixed-Content-Warnungen im HTTPS-Modus gefixt (betreffen die Karten-Bilder und den Meshviewer-Iframe).

Ich hab jetzt [Protokoll-relative URLs](http://www.paulirish.com/2010/the-protocol-relative-url/) benutzt: nur wer die verschlüsselte Seite aufruft, bekommt auch die verschlüsselten Bilder. Wir könnten auch generell immer auf verschlüsselte Bilder verweisen, aber das [erzeugt wohl theoretisch etwas Overhead](http://stackoverflow.com/a/28447177).
